### PR TITLE
soft depend all vault permission plugins linked on vault's plugin page

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 main: me.armar.plugins.autorank.Autorank
 name: Autorank
-softdepend: [Vault, Essentials, GroupManager, Stats, WorldEdit, WorldGuard, Factions, mcMMO, RoyalCommandsm, OnTime]
+softdepend: [Vault, Essentials, GroupManager, Stats, WorldEdit, WorldGuard, Factions, mcMMO, RoyalCommands, OnTime, Privileges, bPermissions, PermissionsEx, PermissionsBukkit, DroxPerms]
 url: http://dev.bukkit.org/bukkit-plugins/autorank/
 version: ${project.version}
 authors: [Idrrp, Armarr, Staartvin]


### PR DESCRIPTION
also fixed a typo in royalcommand's soft depend
