### PR TITLE
Depend on the required plugin Vault

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,7 @@
 main: me.armar.plugins.autorank.Autorank
 name: Autorank
-softdepend: [Vault, Essentials, GroupManager, Stats, WorldEdit, WorldGuard, Factions, mcMMO, RoyalCommands, OnTime, Privileges, bPermissions, PermissionsEx, PermissionsBukkit, DroxPerms]
+depend: [Vault]
+softdepend: [Essentials, GroupManager, Stats, WorldEdit, WorldGuard, Factions, mcMMO, RoyalCommands, OnTime, Privileges, bPermissions, PermissionsEx, PermissionsBukkit, DroxPerms]
 url: http://dev.bukkit.org/bukkit-plugins/autorank/
 version: ${project.version}
 authors: [Idrrp, Armarr, Staartvin]


### PR DESCRIPTION
Vault needs to be directly depended on or given a more proper fail message.
