### PR TITLE
Check for dependencies after all plugins have loaded

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,5 @@
 main: me.armar.plugins.autorank.Autorank
 name: Autorank
-softdepend: [Vault, GroupManager, Privileges, bPermissions, PermissionsEx, PermissionsBukkit, DroxPerms, PowerfulPerms, Statz]
 url: http://dev.bukkit.org/bukkit-plugins/autorank/
 version: ${project.version}
 authors: [Idrrp, Armarr, Staartvin]

--- a/src/me/armar/plugins/autorank/Autorank.java
+++ b/src/me/armar/plugins/autorank/Autorank.java
@@ -229,15 +229,20 @@ public class Autorank extends JavaPlugin {
 		// Load dependency manager
 		setDependencyManager(new DependencyManager(this));
 
-		try {
-			// Load dependencies
-			dependencyManager.loadDependencies();
-		} catch (final Throwable t) {
+		getServer().getScheduler().runTaskLater(this, new Runnable() {
+			@Override
+			public void run() {
+				try {
+					// Load dependencies
+					dependencyManager.loadDependencies();
+				} catch (final Throwable t) {
 
-			// When an error occured!
+					// When an error occured!
 
-			getLogger().severe("Could not hook into a dependency: \nCause: " + t.getCause());
-		}
+					getLogger().severe("Could not hook into a dependency: \nCause: " + t.getCause());
+				}
+			}
+		}, 1L);
 
 		// Create playtime class
 		setPlaytimes(new Playtimes(this));


### PR DESCRIPTION
There are a huge variety of permission plugins, so using soft-depend is not a sensible option. Unless a user is using one of the permission plugins in the list, it's entirely down to luck as to whether the plugin will work or not.

It makes much more sense to wait for the server to start, and let all plugins load, before checking for dependencies, especially when you're depending on a type of plugin, not one of a specific name.

Since you retrieve the Vault permission interface on load, if another is plugin enabled afterwards and overrides the default super-perms implementation, this will not be picked up by Autorank.
http://i.imgur.com/GLjrVAF.png

This PR fixes this.